### PR TITLE
Add fract()

### DIFF
--- a/src/main/kotlin/com/curiouscreature/kotlin/math/Scalar.kt
+++ b/src/main/kotlin/com/curiouscreature/kotlin/math/Scalar.kt
@@ -36,4 +36,6 @@ inline fun degrees(v: Float) = v * (180.0f * INV_PI)
 
 inline fun radians(v: Float) = v * (PI / 180.0f)
 
+inline fun fract(v: Float) = v % 1
+
 inline fun sqr(v: Float) = v * v


### PR DESCRIPTION
This implementation relies on the behavior of Java’s remainder operator
to work with negative numbers (as opposed to x - floor(x))