### PR TITLE
Make Half, Vectors, Matrices, Quaternion, and Ray serializable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import java.net.URL
 
 plugins {
     kotlin("multiplatform") version "1.7.21"
+    kotlin("plugin.serialization") version "1.7.21"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
     id("org.jetbrains.dokka") version "1.7.20"
     id("maven-publish")
@@ -60,6 +61,7 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(kotlin("stdlib-common"))
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.5.1")
             }
         }
         commonTest {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=dev.romainguy
-VERSION_NAME=1.5.3
+VERSION_NAME=1.5.4
 
 POM_DESCRIPTION=Graphics oriented math library for Kotlin
 

--- a/src/commonMain/kotlin/dev/romainguy/kotlin/math/Half.kt
+++ b/src/commonMain/kotlin/dev/romainguy/kotlin/math/Half.kt
@@ -21,6 +21,7 @@ package dev.romainguy.kotlin.math
 
 import dev.romainguy.kotlin.math.Half.Companion.POSITIVE_INFINITY
 import dev.romainguy.kotlin.math.Half.Companion.POSITIVE_ZERO
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 
 /**
@@ -251,6 +252,7 @@ fun Rational.toHalf() = toFloat().toHalf()
  * This table shows that numbers higher than 1024 lose all fractional precision.
  */
 @JvmInline
+@Serializable
 value class Half(private val v: UShort) : Comparable<Half> {
     companion object {
         /**

--- a/src/commonMain/kotlin/dev/romainguy/kotlin/math/Matrix.kt
+++ b/src/commonMain/kotlin/dev/romainguy/kotlin/math/Matrix.kt
@@ -18,6 +18,7 @@
 
 package dev.romainguy.kotlin.math
 
+import kotlinx.serialization.Serializable
 import kotlin.math.*
 
 enum class MatrixColumn {
@@ -36,6 +37,7 @@ enum class RotationsOrder(
     ZYX(VectorComponent.Z, VectorComponent.Y, VectorComponent.X);
 }
 
+@Serializable
 data class Mat2(
         var x: Float2 = Float2(x = 1.0f),
         var y: Float2 = Float2(y = 1.0f)) {
@@ -128,6 +130,7 @@ data class Mat2(
     }
 }
 
+@Serializable
 data class Mat3(
         var x: Float3 = Float3(x = 1.0f),
         var y: Float3 = Float3(y = 1.0f),
@@ -238,6 +241,7 @@ data class Mat3(
     }
 }
 
+@Serializable
 data class Mat4(
         var x: Float4 = Float4(x = 1.0f),
         var y: Float4 = Float4(y = 1.0f),

--- a/src/commonMain/kotlin/dev/romainguy/kotlin/math/Quaternion.kt
+++ b/src/commonMain/kotlin/dev/romainguy/kotlin/math/Quaternion.kt
@@ -18,6 +18,7 @@
 
 package dev.romainguy.kotlin.math
 
+import kotlinx.serialization.Serializable
 import kotlin.math.*
 enum class QuaternionComponent {
     X, Y, Z, W
@@ -28,6 +29,7 @@ enum class QuaternionComponent {
  * The Quaternion will be normalized during construction
  * Default: Identity
  */
+@Serializable
 data class Quaternion(
         var x: Float = 0.0f,
         var y: Float = 0.0f,

--- a/src/commonMain/kotlin/dev/romainguy/kotlin/math/Rational.kt
+++ b/src/commonMain/kotlin/dev/romainguy/kotlin/math/Rational.kt
@@ -18,6 +18,7 @@
 
 package dev.romainguy.kotlin.math
 
+import kotlinx.serialization.Serializable
 import kotlin.jvm.JvmInline
 import kotlin.math.abs
 import kotlin.math.sign
@@ -31,6 +32,7 @@ fun Rational(value: Int) = Rational(pack(value, 1))
 fun Rational(numerator: Int, denominator: Int) = Rational(pack(numerator, denominator))
 
 @JvmInline
+@Serializable
 value class Rational(private val r: Long) : Comparable<Rational> {
     companion object {
         val NaN = Rational(0, 0)

--- a/src/commonMain/kotlin/dev/romainguy/kotlin/math/Ray.kt
+++ b/src/commonMain/kotlin/dev/romainguy/kotlin/math/Ray.kt
@@ -18,6 +18,9 @@
 
 package dev.romainguy.kotlin.math
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Ray(var origin: Float3 = Float3(), var direction: Float3)
 
 fun pointAt(r: Ray, t: Float) = r.origin + r.direction * t

--- a/src/commonMain/kotlin/dev/romainguy/kotlin/math/Vector.kt
+++ b/src/commonMain/kotlin/dev/romainguy/kotlin/math/Vector.kt
@@ -24,6 +24,7 @@ import kotlin.math.min
 import kotlin.math.sqrt
 import kotlin.math.acos
 import kotlin.math.absoluteValue
+import kotlinx.serialization.Serializable
 
 enum class VectorComponent {
     X, Y, Z, W,
@@ -31,6 +32,7 @@ enum class VectorComponent {
     S, T, P, Q
 }
 
+@Serializable
 data class Float2(var x: Float = 0.0f, var y: Float = 0.0f) {
     constructor(v: Float) : this(v, v)
     constructor(v: Float2) : this(v.x, v.y)
@@ -153,6 +155,7 @@ data class Float2(var x: Float = 0.0f, var y: Float = 0.0f) {
     fun toFloatArray() = floatArrayOf(x, y)
 }
 
+@Serializable
 data class Float3(var x: Float = 0.0f, var y: Float = 0.0f, var z: Float = 0.0f) {
     constructor(v: Float) : this(v, v, v)
     constructor(v: Float2, z: Float = 0.0f) : this(v.x, v.y, z)
@@ -342,6 +345,7 @@ data class Float3(var x: Float = 0.0f, var y: Float = 0.0f, var z: Float = 0.0f)
     fun toFloatArray() = floatArrayOf(x, y, z)
 }
 
+@Serializable
 data class Float4(
         var x: Float = 0.0f,
         var y: Float = 0.0f,
@@ -958,6 +962,7 @@ inline infix fun Float4.neq(b: Float4) = Bool4(x != b.x, y != b.y, z != b.z, w !
 inline fun any(v: Bool4) = v.x || v.y || v.z || v.w
 inline fun all(v: Bool4) = v.x && v.y && v.z && v.w
 
+@Serializable
 data class Bool2(var x: Boolean = false, var y: Boolean = false) {
     constructor(v: Bool2) : this(v.x, v.y)
 
@@ -1045,6 +1050,7 @@ data class Bool2(var x: Boolean = false, var y: Boolean = false) {
     }
 }
 
+@Serializable
 data class Bool3(var x: Boolean = false, var y: Boolean = false, var z: Boolean = false) {
     constructor(v: Bool2, z: Boolean = false) : this(v.x, v.y, z)
     constructor(v: Bool3) : this(v.x, v.y, v.z)
@@ -1189,6 +1195,7 @@ data class Bool3(var x: Boolean = false, var y: Boolean = false, var z: Boolean 
     }
 }
 
+@Serializable
 data class Bool4(
         var x: Boolean = false,
         var y: Boolean = false,
@@ -1403,6 +1410,7 @@ data class Bool4(
     }
 }
 
+@Serializable
 data class Half2(var x: Half = Half.POSITIVE_ZERO, var y: Half = Half.POSITIVE_ZERO) {
     constructor(v: Half) : this(v, v)
     constructor(v: Half2) : this(v.x, v.y)
@@ -1513,6 +1521,7 @@ data class Half2(var x: Half = Half.POSITIVE_ZERO, var y: Half = Half.POSITIVE_Z
     fun toFloatArray() = floatArrayOf(x.toFloat(), y.toFloat())
 }
 
+@Serializable
 data class Half3(
     var x: Half = Half.POSITIVE_ZERO,
     var y: Half = Half.POSITIVE_ZERO,
@@ -1690,6 +1699,7 @@ data class Half3(
     fun toFloatArray() = floatArrayOf(x.toFloat(), y.toFloat(), z.toFloat())
 }
 
+@Serializable
 data class Half4(
     var x: Half = Half.POSITIVE_ZERO,
     var y: Half = Half.POSITIVE_ZERO,


### PR DESCRIPTION
## Motivation
I am using kotlin-math on my game engine and need vectors and matrices to be serializable  to model my scene. To achieve this, I forked and added serialization using `kotlinx-serialization`. The serialization library maaintains the multiplatform nature of `kotlin-math`.

## Changes
- Added `kotlinx-serialization` dependency
- Added the @Serializable annotation to `Half`, `Mat2`, `Mat3`, `Mat4`, `Quaternion`, `Rational`, `Ray`, `Float2`, `Float3`, `Float4`, `Bool2`, `Bool3`, `Bool4`, `Half2`, `Half3`, and `Half4`

I hope you find my contribution useful.