### PR TITLE
Enable androidNativeArm64 target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,34 +18,30 @@ repositories {
 }
 
 kotlin {
-    targets {
-        jvm()
+    jvm()
 
-        js {
-            browser()
-            nodejs()
-        }
+    js {
+        browser()
+        nodejs()
+    }
 
-        if (HostManager.hostIsMac) {
-            macosX64()
-            macosArm64()
-            iosX64()
-            iosArm64()
-            iosSimulatorArm64()
-            watchosX64()
-            watchosArm64()
-            watchosSimulatorArm64()
-        }
+    // Tier 1
+    macosArm64()
+    iosArm64()
+    iosSimulatorArm64()
 
-        if (HostManager.hostIsMingw || HostManager.hostIsMac) {
-            mingwX64 {
-                binaries.findTest(DEBUG)!!.linkerOpts = mutableListOf("-Wl,--subsystem,windows")
-            }
-        }
+    // Tier 2
+    linuxX64()
+    macosX64()
+    iosX64()
+    watchosArm64()
+    watchosSimulatorArm64()
+    watchosX64()
 
-        if (HostManager.hostIsLinux || HostManager.hostIsMac) {
-            linuxX64()
-        }
+    // Tier 3
+    androidNativeArm64()
+    mingwX64 {
+        binaries.findTest(DEBUG)!!.linkerOpts = mutableListOf("-Wl,--subsystem,windows")
     }
 
     sourceSets {

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,5 @@ POM_DEVELOPER_URL=https://github.com/romainguy
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
+
+kotlin.native.ignoreDisabledTargets=true


### PR DESCRIPTION
I checked that `./gradlew build` passes on macOS, Windows and Linux, except for some pre-existing test failures on JS targets:

```
> Task :jsNodeTest

dev.romainguy.kotlin.math.HalfTest.string[js, node] FAILED
    AssertionError at /Users/user/Projects/kotlin-math/build/compileSync/js/test/testDevelopmentExecutable/kotlin/js/src/main/kotlin/kotlin/test/JsImpl.kt:23

dev.romainguy.kotlin.math.RationalTest.fromFloat[js, node] FAILED
    AssertionError at /Users/user/Projects/kotlin-math/build/compileSync/js/test/testDevelopmentExecutable/kotlin/js/src/main/kotlin/kotlin/test/JsImpl.kt:23
```

Fixes #61