### PR TITLE
Support `toFloatArrayColumn` on Mat*

### DIFF
--- a/src/commonMain/kotlin/dev/romainguy/kotlin/math/Matrix.kt
+++ b/src/commonMain/kotlin/dev/romainguy/kotlin/math/Matrix.kt
@@ -115,9 +115,20 @@ data class Mat2(
             x.y * v.x + y.y * v.y,
     )
 
+    /**
+     * This matrix as a [FloatArray] in row-major order
+     */
     fun toFloatArray() = floatArrayOf(
             x.x, y.x,
             x.y, y.y
+    )
+
+    /**
+     * This matrix as a [FloatArray] in column-major order
+     */
+    fun toFloatArrayColumn() = floatArrayOf(
+        x.x, x.y,
+        y.x, y.y
     )
 
     override fun toString(): String {
@@ -223,10 +234,22 @@ data class Mat3(
             x.z * v.x + y.z * v.y + z.z * v.z,
     )
 
+    /**
+     * This matrix as a [FloatArray] in row-major order
+     */
     fun toFloatArray() = floatArrayOf(
             x.x, y.x, z.x,
             x.y, y.y, z.y,
             x.z, y.z, z.z
+    )
+
+    /**
+     * This matrix as a [FloatArray] in column-major order
+     */
+    fun toFloatArrayColumn() = floatArrayOf(
+        x.x, x.y, x.z,
+        y.x, y.y, y.z,
+        z.x, z.y, z.z
     )
 
     override fun toString(): String {
@@ -415,11 +438,24 @@ data class Mat4(
      */
     fun toQuaternion() = quaternion(this)
 
+    /**
+     * This matrix as a [FloatArray] in row-major order
+     */
     fun toFloatArray() = floatArrayOf(
             x.x, y.x, z.x, w.x,
             x.y, y.y, z.y, w.y,
             x.z, y.z, z.z, w.z,
             x.w, y.w, z.w, w.w
+    )
+
+    /**
+     * This matrix as a [FloatArray] in column-major order
+     */
+    fun toFloatArrayColumn() = floatArrayOf(
+        x.x, x.y, x.z, x.w,
+        y.x, y.y, y.z, y.w,
+        z.x, z.y, z.z, z.w,
+        w.x, w.y, w.z, w.w
     )
 
     override fun toString(): String {

--- a/src/commonTest/kotlin/dev/romainguy/kotlin/math/MatrixTest.kt
+++ b/src/commonTest/kotlin/dev/romainguy/kotlin/math/MatrixTest.kt
@@ -241,6 +241,24 @@ class MatrixTest {
     }
 
     @Test
+    fun floatArrayColumn() {
+        assertArrayEquals(
+            floatArrayOf(
+                1f, 2f, 3f, 4f,
+                4f, 5f, 6f, 7f,
+                8f, 9f, 10f, 11f,
+                12f, 13f, 14f, 15f
+            ),
+            Mat4(
+                Float4(1f, 2f, 3f, 4f),
+                Float4(4f, 5f, 6f, 7f),
+                Float4(8f, 9f, 10f, 11f),
+                Float4(12f, 13f, 14f, 15f)
+            ).toFloatArrayColumn()
+        )
+    }
+
+    @Test
     fun inverseNonInvertibleMat4() {
         val expected = Mat4(
             Float4(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.NaN, Float.NaN),


### PR DESCRIPTION
This is useful for shoving this data into an array buffer for webgl/gpu to consume, and IMO a second method showing up on auto-complete would avoid surprises for anyone that would expect it to be that way by default.

The default `toFloatArray` spitting out row-major was a pretty big surprise, and [it looks like I wasn't the only one bit by it](https://github.com/romainguy/kotlin-math/issues/66)

The internal interface was *maybe* overkill? But IMO worth not having to duplicate the documentation, and with it in place it would be nice enough to do the same with a few other methods...