### PR TITLE
Added target watchosDeviceArm64

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ kotlin {
     macosX64()
     iosX64()
     watchosArm64()
+    watchosDeviceArm64()
     watchosSimulatorArm64()
     watchosX64()
 


### PR DESCRIPTION
This is a new target required for WatchOS releases to be added